### PR TITLE
Perbuild, Pervisit fix

### DIFF
--- a/Commands/CmdPermissionBuild.cs
+++ b/Commands/CmdPermissionBuild.cs
@@ -42,6 +42,11 @@ namespace MCForge.Commands
                         Player.SendMessage(p, "You cannot change the perbuild of a level with a perbuild higher than your rank.");
                         return;
                     }
+                    else if (Perm > p.group.Permission)
+                    {
+                        Player.SendMessage(p, "You cannot set the build permission higher than your rank.");
+                        return;
+                    }
                     p.level.permissionbuild = Perm;
                     Level.SaveSettings(p.level);
                     Server.s.Log(p.level.name + " build permission changed to " + message + ".");
@@ -62,10 +67,7 @@ namespace MCForge.Commands
                         {
                             Player.SendMessage(p, "You cannot change the perbuild of a level with a perbuild higher than your rank.");
                             return;
-                        } else if ( Perm > p.group.Permission ) {
-                            Player.SendMessage( p, "You cannot set the build permission higher than your own." );
-                            return;
-                        }
+                        } 
 
                         level.permissionbuild = Perm;
                         Level.SaveSettings(level);

--- a/Commands/CmdPermissionVisit.cs
+++ b/Commands/CmdPermissionVisit.cs
@@ -42,6 +42,11 @@ namespace MCForge.Commands
                         Player.SendMessage(p, "You cannot change the pervisit of a level with a pervisit higher than your rank.");
                         return;
                     }
+                    else if (Perm > p.group.Permission)
+                    {
+                        Player.SendMessage(p, "You cannot set the visit permission higher than your own rank.");
+                        return;
+                    }
                     p.level.permissionvisit = Perm;
                     Level.SaveSettings(p.level);
                     Server.s.Log(p.level.name + " visit permission changed to " + message + ".");


### PR DESCRIPTION
Perbuild was still allowing the user to set a build permission higher
than their rank, pervisit had the same issue, this should fix it.
