### PR TITLE
Improvements to level saving

### DIFF
--- a/Levels/Level.cs
+++ b/Levels/Level.cs
@@ -1018,11 +1018,14 @@ namespace MCForge
                     {
                         physic.ClearPhysics(this);
                     }
-                    using (FileStream fs = File.Create(string.Format("{0}.back", path)))
+                    
+                    string backFile = string.Format("{0}.back", path);
+                    string backupFile = string.Format("{0}.backup", path);
+                    
+                    using (FileStream fs = File.OpenWrite(backFile))
                     {
                         using (GZipStream gs = new GZipStream(fs, CompressionMode.Compress))
                         {
-
                             var header = new byte[16];
                             BitConverter.GetBytes(1874).CopyTo(header, 0);
                             gs.Write(header, 0, 2);
@@ -1030,6 +1033,7 @@ namespace MCForge
                             BitConverter.GetBytes(width).CopyTo(header, 0);
                             BitConverter.GetBytes(height).CopyTo(header, 2);
                             BitConverter.GetBytes(depth).CopyTo(header, 4);
+                    	    changed = false;
                             BitConverter.GetBytes(spawnx).CopyTo(header, 6);
                             BitConverter.GetBytes(spawnz).CopyTo(header, 8);
                             BitConverter.GetBytes(spawny).CopyTo(header, 10);
@@ -1058,22 +1062,24 @@ namespace MCForge
                                 }
                             }
                             gs.Write(level, 0, level.Length);
-                            gs.Close();
-                            File.Delete(string.Format("{0}.backup", path));
-                            File.Copy(string.Format("{0}.back", path), path + ".backup");
-                            File.Delete(path);
-                            File.Move(string.Format("{0}.back", path), path);
-
-                            SaveSettings(this);
-
-                            Server.s.Log(string.Format("SAVED: Level \"{0}\". ({1}/{2}/{3})", name, players.Count,
-                                                       Player.players.Count, Server.players));
-                            changed = false;
-
-                            gs.Dispose();
-                            fs.Dispose();
                         }
                     }
+
+					// Safely replace the original file (if it exists) after making a backup.
+                    if (File.Exists(path))
+                    {
+                    	File.Delete(backupFile);
+                    	File.Replace(backFile, path, backupFile);
+                    }
+                    else
+                    {
+                    	File.Move(backFile, path);
+                    }
+
+                    SaveSettings(this);
+
+                    Server.s.Log(string.Format("SAVED: Level \"{0}\". ({1}/{2}/{3})", name, players.Count,
+                                               Player.players.Count, Server.players));
 
                     // UNCOMPRESSED LEVEL SAVING! DO NOT USE!
                     /*using (FileStream fs = File.Create(path + ".wtf"))


### PR DESCRIPTION
1) Avoid manually calling Close/Dispose on streams -- it's done automatically when using() scope is exited.
2) Reset "changed" BEFORE saving, to ensure that any changes that happen during the saving process are not ignored in the future.
3) Use File.OpenWrite() instead of File.Create(), which does not throw exception if target file already exists.
4) Use File.Replace() instead of File.Move() to safely (atomically) replace existing files and make backups.
